### PR TITLE
feat: Handle scss, sass or less as input correctly

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -232,6 +232,11 @@ class Manifest
         $tags = [];
 
         foreach ($chunks as $chunk) {
+            if ($chunk->isEntry && str_ends_with($chunk->file, '.css')) {
+                $tags[] = "<link rel=\"stylesheet\" href=\"{$this->base_path}{$chunk->file}\" />";
+                continue;
+            }
+
             foreach ($chunk->css as $css) {
                 $tags[] = "<link rel=\"stylesheet\" href=\"{$this->base_path}{$css}\" />";
             }
@@ -248,7 +253,7 @@ class Manifest
         $tags = [];
 
         foreach ($chunks as $chunk) {
-            if ($chunk->isEntry) {
+            if ($chunk->isEntry && str_ends_with($chunk->file, '.js')) {
                 $tags[] = "<script type=\"module\" src=\"{$this->base_path}{$chunk->file}\"></script>";
             }
         }


### PR DESCRIPTION
Currently, inputs of type scss, sass or less are rendered with the script tag. This pull request ensures that the link tag provided for this purpose is used.

Here is an example vite configuration that can be used to simulate the problem:
```typescript
...

export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
  ...

  return {
    server: {
      origin: 'http://foo.bar',
      ...
    },
    build: {
      manifest: true,
      rollupOptions: {
        input: ['./src/foo.tsx', './src/scss/bar.scss'],
        ...
      },
    },
    ...
  }
})
```