### PR TITLE
allow (s)css and image files as entry points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
     steps:
       - uses: shivammathur/setup-php@2.30.4
         with:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MPL-2.0",
     "description": "a lightweight PHP-backend integration for the Vite frontend build tool",
     "scripts": {
-        "test": "XDEBUG_MODE=coverage php test/test.php"
+        "test": "XDEBUG_MODE=coverage php test/test.php -v"
     },
     "autoload": {
         "psr-4": {

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -235,6 +235,10 @@ class Manifest
             foreach ($chunk->css as $css) {
                 $tags[] = "<link rel=\"stylesheet\" href=\"{$this->base_path}{$css}\" />";
             }
+
+            if (str_ends_with($chunk->file, '.css') && $chunk->isEntry) {
+                $tags[] = "<link rel=\"stylesheet\" href=\"{$this->base_path}{$chunk->file}\" />";
+            }
         }
 
         return implode("\n", $tags);
@@ -248,7 +252,7 @@ class Manifest
         $tags = [];
 
         foreach ($chunks as $chunk) {
-            if ($chunk->isEntry) {
+            if (str_ends_with($chunk->file, '.js') && $chunk->isEntry) {
                 $tags[] = "<script type=\"module\" src=\"{$this->base_path}{$chunk->file}\"></script>";
             }
         }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -121,6 +121,17 @@ class Manifest
     }
 
     /**
+     * Register MIME types for preloading common web font formats.
+     */
+    public function preloadStyles(): void
+    {
+        $this->preload_types = [
+            ...$this->preload_types,
+            'css' => ['type' => 'text/css', 'as' => 'style'],
+        ];
+    }
+
+    /**
      * Create preload, CSS and JS tags for the specified entry point script(s).
      *
      * Entry points are defined in Vite's `build.rollupOptions` using RollUp's `input` setting.
@@ -204,6 +215,14 @@ class Manifest
 
             if (str_ends_with($chunk->file, '.js')) {
                 $tags[] = "<link rel=\"modulepreload\" href=\"{$this->base_path}{$chunk->file}\" />";
+            }
+
+            if (str_ends_with($chunk->file, '.css') && isset($this->preload_types['css'])) {
+                $preload = $this->preload_types['css'];
+                $type = $preload['type'];
+                $as = $preload['as'];
+
+                $tags[] = "<link rel=\"preload\" as=\"{$as}\" type=\"{$type}\" href=\"{$this->base_path}{$chunk->file}\" />";
             }
 
             // Preload assets:

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -217,15 +217,17 @@ class Manifest
                 $tags[] = "<link rel=\"modulepreload\" href=\"{$this->base_path}{$chunk->file}\" />";
             }
 
-            if (str_ends_with($chunk->file, '.css') && isset($this->preload_types['css'])) {
-                $preload = $this->preload_types['css'];
+            // Preload assets:
+
+            ['extension' => $extension] = pathinfo($chunk->file);
+
+            if (isset($this->preload_types[$extension])) {
+                $preload = $this->preload_types[$extension];
                 $type = $preload['type'];
                 $as = $preload['as'];
 
                 $tags[] = "<link rel=\"preload\" as=\"{$as}\" type=\"{$type}\" href=\"{$this->base_path}{$chunk->file}\" />";
             }
-
-            // Preload assets:
 
             foreach ($chunk->assets as $asset) {
                 $type = substr($asset, strrpos($asset, '.') + 1);
@@ -288,10 +290,6 @@ class Manifest
 
             if ($chunk === null) {
                 throw new RuntimeException("Entry not found in manifest: {$entry}");
-            }
-
-            if (! $chunk->isEntry) {
-                throw new RuntimeException("Chunk is not an entry point: {$entry}");
             }
 
             $chunks[$entry] = $chunk;

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -292,6 +292,10 @@ class Manifest
                 throw new RuntimeException("Entry not found in manifest: {$entry}");
             }
 
+            if ((str_ends_with($chunk->file, '.js') || str_ends_with($chunk->file, '.css')) && ! $chunk->isEntry) {
+                throw new RuntimeException("Chunk is not an entry point: {$entry}");
+            }
+
             $chunks[$entry] = $chunk;
 
             // Recursively find all statically imported chunks:

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -121,7 +121,7 @@ class Manifest
     }
 
     /**
-     * Register MIME types for preloading common web font formats.
+     * Register MIME types for preloading stylesheets.
      */
     public function preloadStyles(): void
     {
@@ -292,6 +292,7 @@ class Manifest
                 throw new RuntimeException("Entry not found in manifest: {$entry}");
             }
 
+            // only check .js and .css files, because images dont get the "isEntry" information in the manifest
             if ((str_ends_with($chunk->file, '.js') || str_ends_with($chunk->file, '.css')) && ! $chunk->isEntry) {
                 throw new RuntimeException("Chunk is not an entry point: {$entry}");
             }

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -39,5 +39,21 @@
         "css": [
             "assets/shared.a834bfc3.css"
         ]
+    },
+    "public/scss/themes/admin/admin.scss": {
+        "file": "assets/admin-B8_LVhy3.css",
+        "src": "public/scss/themes/admin/admin.scss",
+        "isEntry": true,
+        "names": [
+            "admin.css"
+        ]
+    },
+    "public/css/plus.css": {
+        "file": "assets/plus-DwWFnKP0.css",
+        "src": "public/css/plus.css",
+        "isEntry": true,
+        "names": [
+            "plus.css"
+        ]
     }
 }

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -55,5 +55,9 @@
         "names": [
             "plus.css"
         ]
+    },
+    "public/img/favicon.ico": {
+        "file": "assets/favicon-zR_S-YMI.ico",
+        "src": "public/img/favicon.ico"
     }
 }

--- a/test/test.php
+++ b/test/test.php
@@ -98,6 +98,8 @@ test(
         );
 
         $vite->preloadImages();
+        $vite->preloadFonts();
+        $vite->preloadStyles();
 
         $tags = $vite->createTags("main.js", "consent-banner.js", "public/scss/themes/admin/admin.scss", "public/css/plus.css");
 
@@ -111,6 +113,8 @@ test(
                 '<link rel="modulepreload" href="/dist/assets/shared.83069a53.js" />',
                 // Preload `views/foo.js` entry point script:
                 '<link rel="modulepreload" href="/dist/assets/consent-banner.0e3b3b7b.js" />',
+                '<link rel="preload" as="style" type="text/css" href="/dist/assets/admin-B8_LVhy3.css" />',
+                '<link rel="preload" as="style" type="text/css" href="/dist/assets/plus-DwWFnKP0.css" />',
             ],
         );
 

--- a/test/test.php
+++ b/test/test.php
@@ -101,7 +101,7 @@ test(
         $vite->preloadFonts();
         $vite->preloadStyles();
 
-        $tags = $vite->createTags("main.js", "consent-banner.js", "public/scss/themes/admin/admin.scss", "public/css/plus.css");
+        $tags = $vite->createTags("main.js", "consent-banner.js", "public/scss/themes/admin/admin.scss", "public/css/plus.css", "public/img/favicon.ico");
 
         eq(
             explode("\n", $tags->preload),
@@ -115,6 +115,7 @@ test(
                 '<link rel="modulepreload" href="/dist/assets/consent-banner.0e3b3b7b.js" />',
                 '<link rel="preload" as="style" type="text/css" href="/dist/assets/admin-B8_LVhy3.css" />',
                 '<link rel="preload" as="style" type="text/css" href="/dist/assets/plus-DwWFnKP0.css" />',
+                '<link rel="preload" as="image" type="image/x-icon" href="/dist/assets/favicon-zR_S-YMI.ico" />',
             ],
         );
 

--- a/test/test.php
+++ b/test/test.php
@@ -98,7 +98,6 @@ test(
         );
 
         $vite->preloadImages();
-        $vite->preloadFonts();
         $vite->preloadStyles();
 
         $tags = $vite->createTags("main.js", "consent-banner.js", "public/scss/themes/admin/admin.scss", "public/css/plus.css", "public/img/favicon.ico");

--- a/test/test.php
+++ b/test/test.php
@@ -99,7 +99,7 @@ test(
 
         $vite->preloadImages();
 
-        $tags = $vite->createTags("main.js", "consent-banner.js");
+        $tags = $vite->createTags("main.js", "consent-banner.js", "public/scss/themes/admin/admin.scss", "public/css/plus.css");
 
         eq(
             explode("\n", $tags->preload),
@@ -123,6 +123,8 @@ test(
                 '<link rel="stylesheet" href="/dist/assets/shared.a834bfc3.css" />',
                 // CSS imported by the consent-banner entry point script:
                 '<link rel="stylesheet" href="/dist/assets/consent-banner.8ba40300.css" />',
+                '<link rel="stylesheet" href="/dist/assets/admin-B8_LVhy3.css" />',
+                '<link rel="stylesheet" href="/dist/assets/plus-DwWFnKP0.css" />',
             ]
         );
 


### PR DESCRIPTION
Our company uses a Laminas-based PHP application. We use plain native JS and Bootstrap with Sass. So we need (S)CSS files as Entry points. We also want to use Vite for Image optimisation and need Image Entry points too.

This PR is inspired by PR #4.