### PR TITLE
add the crossorigin attribute when generating preload tags of type font and fetch

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -226,7 +226,9 @@ class Manifest
                 $type = $preload['type'];
                 $as = $preload['as'];
 
-                $tags[] = "<link rel=\"preload\" as=\"{$as}\" type=\"{$type}\" href=\"{$this->base_path}{$chunk->file}\" />";
+                $crossorigin = ($as === 'font' || $as === 'fetch') ? "crossorigin" : "";
+
+                $tags[] = "<link rel=\"preload\" as=\"{$as}\" type=\"{$type}\" href=\"{$this->base_path}{$chunk->file}\" $crossorigin/>";
             }
 
             foreach ($chunk->assets as $asset) {
@@ -237,7 +239,9 @@ class Manifest
                     $type = $preload['type'];
                     $as = $preload['as'];
 
-                    $tags[] = "<link rel=\"preload\" as=\"{$as}\" type=\"{$type}\" href=\"{$this->base_path}{$asset}\" />";
+                    $crossorigin = ($as === 'font' || $as === 'fetch') ? "crossorigin" : "";
+
+                    $tags[] = "<link rel=\"preload\" as=\"{$as}\" type=\"{$type}\" href=\"{$this->base_path}{$asset}\" $crossorigin/>";
                 }
             }
         }


### PR DESCRIPTION
This PR fixes issue #8

When generating `<link>` tags for preloading resources, check whether the preload type is `font` or `fetch` and set the `crossorigin` attribute on the tag.